### PR TITLE
add variant percentage to weapon name in wishlist.txt

### DIFF
--- a/lib/asher_mir.rb
+++ b/lib/asher_mir.rb
@@ -20,7 +20,7 @@ class AsherMir
 
   def wishlist(variant)
     results = StringIO.new
-    results << "//notes:#{variant.name}"
+    results << "//notes:#{variant.name} (#{'%.3f' % variant.probability}%)"
     results << "\n"
     results << entries(variant).split("\n").sort.join("\n")
     results.string

--- a/spec/data/asher_mir_spec/variant_0.txt
+++ b/spec/data/asher_mir_spec/variant_0.txt
@@ -1,4 +1,4 @@
-//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️🏃‍♂️🌟 Collector's Edition
+//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️🏃‍♂️🌟 Collector's Edition (0.044%)
 dimwishlist:item=1119734784&perks=839105230,3177308360,2946784966,1015611457,150943600
 dimwishlist:item=1119734784&perks=839105230,3177308360,2946784966,1015611457,150943601
 dimwishlist:item=1119734784&perks=839105230,3177308360,2946784966,1015611457,150943602

--- a/spec/data/asher_mir_spec/variant_1.txt
+++ b/spec/data/asher_mir_spec/variant_1.txt
@@ -1,4 +1,4 @@
-//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️🏃‍♂️ CE (+barrels)
+//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️🏃‍♂️ CE (+barrels) (0.083%)
 dimwishlist:item=1119734784&perks=1392496348,3177308360,2946784966,1015611457,150943600
 dimwishlist:item=1119734784&perks=1392496348,3177308360,2946784966,1015611457,150943601
 dimwishlist:item=1119734784&perks=1392496348,3177308360,2946784966,1015611457,150943602

--- a/spec/data/asher_mir_spec/variant_2.txt
+++ b/spec/data/asher_mir_spec/variant_2.txt
@@ -1,4 +1,4 @@
-//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️🏃‍♂️ CE (+magazines)
+//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️🏃‍♂️ CE (+magazines) (0.081%)
 dimwishlist:item=1119734784&perks=839105230,3142289711,2946784966,1015611457,150943600
 dimwishlist:item=1119734784&perks=839105230,3142289711,2946784966,1015611457,150943601
 dimwishlist:item=1119734784&perks=839105230,3142289711,2946784966,1015611457,150943602

--- a/spec/data/asher_mir_spec/variant_3.txt
+++ b/spec/data/asher_mir_spec/variant_3.txt
@@ -1,2 +1,2 @@
-//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️🏃‍♂️ CE (*masterworks)
+//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️🏃‍♂️ CE (*masterworks) (0.176%)
 dimwishlist:item=1119734784&perks=839105230,3177308360,2946784966,1015611457

--- a/spec/data/asher_mir_spec/variant_4.txt
+++ b/spec/data/asher_mir_spec/variant_4.txt
@@ -1,4 +1,4 @@
-//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️ (+barrels, +magazines)
+//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️ (+barrels, +magazines) (0.152%)
 dimwishlist:item=1119734784&perks=1392496348,3142289711,2946784966,1015611457,150943600
 dimwishlist:item=1119734784&perks=1392496348,3142289711,2946784966,1015611457,150943601
 dimwishlist:item=1119734784&perks=1392496348,3142289711,2946784966,1015611457,150943602

--- a/spec/data/asher_mir_spec/variant_5.txt
+++ b/spec/data/asher_mir_spec/variant_5.txt
@@ -1,3 +1,3 @@
-//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️ (+barrels, *masterworks)
+//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️ (+barrels, *masterworks) (0.331%)
 dimwishlist:item=1119734784&perks=1392496348,3177308360,2946784966,1015611457
 dimwishlist:item=1119734784&perks=839105230,3177308360,2946784966,1015611457

--- a/spec/data/asher_mir_spec/variant_6.txt
+++ b/spec/data/asher_mir_spec/variant_6.txt
@@ -1,3 +1,3 @@
-//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️ (+magazines, *masterworks)
+//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️ (+magazines, *masterworks) (0.323%)
 dimwishlist:item=1119734784&perks=839105230,3142289711,2946784966,1015611457
 dimwishlist:item=1119734784&perks=839105230,3177308360,2946784966,1015611457

--- a/spec/data/asher_mir_spec/variant_7.txt
+++ b/spec/data/asher_mir_spec/variant_7.txt
@@ -1,4 +1,4 @@
-//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️ (+barrels, +magazines, *masterworks)
+//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️🏃‍♂️ (+barrels, +magazines, *masterworks) (0.606%)
 dimwishlist:item=1119734784&perks=1392496348,3142289711,2946784966,1015611457
 dimwishlist:item=1119734784&perks=1392496348,3177308360,2946784966,1015611457
 dimwishlist:item=1119734784&perks=839105230,3142289711,2946784966,1015611457

--- a/spec/data/asher_mir_spec/variant_8.txt
+++ b/spec/data/asher_mir_spec/variant_8.txt
@@ -1,2 +1,2 @@
-//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️ (*barrels, *magazines, *masterworks)
+//notes:[pve,pvp] "Chasing Stability" 🏃‍♂️ (*barrels, *magazines, *masterworks) (2.778%)
 dimwishlist:item=1119734784&perks=2946784966,1015611457


### PR DESCRIPTION
adds the percentage to the variant name so that it's visible on the specific weapon in DIM.

I'm not super familiar with github actions, but I'd set it up on my fork and it auto committed and added the modified wishlist as a commit on this PR automatically.  

I'm assuming that's correct behavior, but if I should strip that off and only submit a PR with my changes, let me know.