### PR TITLE
Update conclusion for Adagio & Tempo bows.

### DIFF
--- a/hugo_site/content/sandbox/weapons/bows.md
+++ b/hugo_site/content/sandbox/weapons/bows.md
@@ -61,11 +61,11 @@ Here are some results from the bows I had on hand, after jumping in to the EDZ a
 |Wolftone Draw|Precision|684ms (Base)|41||
 |||Archer's Tempo|30|`+25% F`|
 |||Adagio|49|`-25% S`|
-|||Adagio + Archer's Tempo|37|`-10% S`|
+|||Adagio + Archer's Tempo|37|`+10% F`|
 |Wolftone Draw|Precision|612ms (Elastic String)|36||
 |||Archer's Tempo|27|`+25% F`|
 |||Adagio|44|`-25% S`|
-|||Adagio + Archer's Tempo|34|`-10% S`|
+|||Adagio + Archer's Tempo|34|`+6% F`|
 
 ### Impulse Amplifier
 


### PR DESCRIPTION
This is _only_ a change to the "conclusion" of the Time To Perfect Draw table. This assumes the TTPD data itself that @rslifka collected is correct, and that I'm representing the percentages the same way.

I intend this as a conversation, too, as it looks like the data contradicts the prose. I'll happily update the prose in this PR as well if we agree that, as the data shows, _Archer's Tempo makes up for Adagio_.